### PR TITLE
Add signal generator toggled by keyboard

### DIFF
--- a/DataGenerator.cpp
+++ b/DataGenerator.cpp
@@ -4,21 +4,36 @@ DataGenerator::DataGenerator(QObject *parent) : QObject(parent) {
     connect(&timer, &QTimer::timeout, this, &DataGenerator::generate);
 }
 
-void DataGenerator::start() {
-    timer.start(10); // generație la 100Hz
+void DataGenerator::startSine(float amp, float freq) {
+    amplitude = amp;
+    frequency = freq;
+    mode = Sine;
+    phase = 0.0f;
+    timer.start(1); // 1ms interval for better resolution
+}
+
+void DataGenerator::startDC(float value) {
+    amplitude = value;
+    frequency = 0.0f;
+    mode = DC;
+    timer.start(10);
 }
 
 void DataGenerator::stop() {
     timer.stop();
-}
-
-void DataGenerator::setAmplitude(int amp) {
-    amplitude = amp;
+    mode = Off;
 }
 
 void DataGenerator::generate() {
-    int ch1 = static_cast<int>(amplitude * std::sin(phase) * 100);
-    int ch2 = static_cast<int>(amplitude * std::cos(phase) * 100);
-    phase += 0.1f;
-    emit newSample(ch1, ch2);
+    int sample = 0;
+    if (mode == Sine) {
+        float dt = timer.interval() / 1000.0f;
+        phase += 2.0f * M_PI * frequency * dt;
+        sample = static_cast<int>(amplitude * std::sin(phase) * 100);
+    } else if (mode == DC) {
+        sample = static_cast<int>(amplitude * 100);
+    } else {
+        return;
+    }
+    emit newSample(sample, sample);
 }

--- a/DataGenerator.h
+++ b/DataGenerator.h
@@ -8,10 +8,13 @@ class DataGenerator : public QObject {
     Q_OBJECT
 
 public:
+    enum Mode { Off, Sine, DC };
+
     explicit DataGenerator(QObject *parent = nullptr);
-    void start();
+
+    void startSine(float amp, float freq);
+    void startDC(float value);
     void stop();
-    void setAmplitude(int amp);
 
 signals:
     void newSample(int ch1, int ch2);
@@ -22,5 +25,7 @@ private slots:
 private:
     QTimer timer;
     float phase = 0.0f;
-    int amplitude = 5;
+    float amplitude = 0.0f;
+    float frequency = 0.0f;
+    Mode mode = Off;
 };

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -5,7 +5,11 @@
 #include <QFileDialog>
 
 MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent), view(new OscilloscopeView), reader(new SerialReader(this)), settings("QtOsc", "Oscilloscope")
+    : QMainWindow(parent),
+      view(new OscilloscopeView),
+      reader(new SerialReader(this)),
+      generator(new DataGenerator(this)),
+      settings("QtOsc", "Oscilloscope")
 {
     setupUI();
     connectSignals();
@@ -18,6 +22,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow() {
     reader->stop();
+    generator->stop();
 }
 
 void MainWindow::setupUI() {
@@ -96,6 +101,7 @@ void MainWindow::connectSignals() {
     connect(startButton, &QPushButton::clicked, this, &MainWindow::startAcquisition);
     connect(stopButton, &QPushButton::clicked, this, &MainWindow::stopAcquisition);
     connect(reader, &SerialReader::newSample, view, &OscilloscopeView::addSample);
+    connect(generator, &DataGenerator::newSample, view, &OscilloscopeView::addSample);
     connect(voltSlider, &QSlider::valueChanged, this, &MainWindow::onVoltSliderChanged);
     connect(timeSlider, &QSlider::valueChanged, this, &MainWindow::onTimeSliderChanged);
     connect(resetButton, &QPushButton::clicked, this, &MainWindow::resetZoom);
@@ -180,4 +186,25 @@ void MainWindow::applyPalette(bool dark) {
 
 void MainWindow::onDarkModeToggled(bool checked) {
     applyPalette(checked);
+}
+
+void MainWindow::keyPressEvent(QKeyEvent *event) {
+    if (event->key() == Qt::Key_S) {
+        if (genMode == DataGenerator::Sine) {
+            generator->stop();
+            genMode = DataGenerator::Off;
+        } else {
+            generator->startSine(230.0f, 50.0f);
+            genMode = DataGenerator::Sine;
+        }
+    } else if (event->key() == Qt::Key_D) {
+        if (genMode == DataGenerator::DC) {
+            generator->stop();
+            genMode = DataGenerator::Off;
+        } else {
+            generator->startDC(12.0f);
+            genMode = DataGenerator::DC;
+        }
+    }
+    QMainWindow::keyPressEvent(event);
 }

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -9,9 +9,11 @@
 #include <QLabel>
 #include <QCheckBox>
 #include <QSettings>
+#include <QKeyEvent>
 
 #include "OscilloscopeView.h"
 #include "SerialReader.h"
+#include "DataGenerator.h"
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -19,6 +21,9 @@ class MainWindow : public QMainWindow {
 public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
+
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
 
 private slots:
     void startAcquisition();
@@ -35,6 +40,8 @@ private slots:
 private:
     OscilloscopeView *view;
     SerialReader *reader;
+    DataGenerator *generator;
+    DataGenerator::Mode genMode = DataGenerator::Off;
     QSlider *timeSlider;
     QLabel *timeLabel;
 


### PR DESCRIPTION
## Summary
- implement `DataGenerator` with sine and DC modes
- integrate generator with `MainWindow`
- toggle 50 Hz 230 V sine on `S`
- toggle 12 V DC on `D`
- include `QKeyEvent` header

## Testing
- `cmake ..` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68549c40c0e0832fb8880f8883ce82b9