### PR TITLE
Fix data generator amplitude

### DIFF
--- a/DataGenerator.cpp
+++ b/DataGenerator.cpp
@@ -29,9 +29,9 @@ void DataGenerator::generate() {
     if (mode == Sine) {
         float dt = timer.interval() / 1000.0f;
         phase += 2.0f * M_PI * frequency * dt;
-        sample = static_cast<int>(amplitude * std::sin(phase) * 100);
+        sample = static_cast<int>(amplitude * std::sin(phase));
     } else if (mode == DC) {
-        sample = static_cast<int>(amplitude * 100);
+        sample = static_cast<int>(amplitude);
     } else {
         return;
     }


### PR DESCRIPTION
## Summary
- correct amplitude scaling in `DataGenerator` to respect peak-to-peak values

## Testing
- `cmake ..` *(fails: FindQt6.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a0153ed8832fb5e480b562513277